### PR TITLE
Fixes missing WAFBUILD_ENV

### DIFF
--- a/Dockerfile.common.default
+++ b/Dockerfile.common.default
@@ -294,6 +294,7 @@ RUN ln -s ${ASTER_DIRECTORY}/asrun/bin/as_run /usr/local/bin/
 RUN rm -rf ${TEMP_DIRECTORY}/*
 
 RUN mkdir -p ${ASTER_DIRECTORY}/aster/lib
+ADD dummy.env ${ASTER_DIRECTORY}/aster/lib
 ADD aster.wafcfg_scif_std.py ${ASTER_DIRECTORY}/aster/lib/scif_std.py
 ADD aster.wafcfg_scif_mpi.py ${ASTER_DIRECTORY}/aster/lib/scif_mpi.py
 ADD aster.wafcfg_scif_boost.py ${ASTER_DIRECTORY}/aster/lib/scif_boost.py

--- a/aster.wafcfg_scif_mpi.py
+++ b/aster.wafcfg_scif_mpi.py
@@ -10,6 +10,7 @@ def configure(self):
     self.env.INCLUDES_BOOST = '/usr/include'
     self.env.LIBPATH_BOOST = ['/usr/lib/x86_64-linux-gnu']
     self.env.LIB_BOOST = ['boost_python3']
+    self.env.WAFBUILD_ENV = ['/aster/aster/lib/dummy.env']
 
     self.env.append_value('LIBPATH', [       
         '/aster/hdf5/lib',

--- a/aster.wafcfg_scif_std.py
+++ b/aster.wafcfg_scif_std.py
@@ -7,6 +7,7 @@ def configure(self):
     self.env['TFELHOME'] = '/aster/tfel'
     self.env['TFELVERS'] = '3.4.0'
     # self.env['CATALO_CMD'] = "DUMMY="
+    self.env.WAFBUILD_ENV = ['/aster/lib/dummy.env']
 
     self.env.append_value('LIBPATH', [
         '/aster/hdf5/lib',

--- a/aster.wafcfg_scif_std.py
+++ b/aster.wafcfg_scif_std.py
@@ -7,7 +7,7 @@ def configure(self):
     self.env['TFELHOME'] = '/aster/tfel'
     self.env['TFELVERS'] = '3.4.0'
     # self.env['CATALO_CMD'] = "DUMMY="
-    self.env.WAFBUILD_ENV = ['/aster/lib/dummy.env']
+    self.env.WAFBUILD_ENV = ['/aster/aster/lib/dummy.env']
 
     self.env.append_value('LIBPATH', [
         '/aster/hdf5/lib',


### PR DESCRIPTION
Hey,

here is my proposal for fixing the compilation fail due to the missing `WAFBUILD_ENV` in newer code aster releases

I've tested this and it worked fine with the latest stable `v15.8.0` (latest at the time of writing).

Using
```
>>> docker run -t aethereng/codeaster-seq:latest run_testcases stable
...

     job             host         started       cpu memory        ended
forma01a       localhost        Mon 01:36:17      1    256 Mon 01:36:22
hsnv100a       localhost        Mon 01:36:17      1    512 Mon 01:36:22
pynl01a        localhost        Mon 01:36:17      1    512 Mon 01:36:22
sdll100a       localhost        Mon 01:36:17      1    512 Mon 01:36:22
sslv155a       localhost        Mon 01:36:17      1    512 Mon 01:36:22
ssnv128a       localhost        Mon 01:36:17      1    512 Mon 01:36:22
zzzz100f       localhost        Mon 01:36:17      1    256 Mon 01:36:22

OK                 All tests run successfully


 
 ---------------------------------------------------------------------------------
                                            cpu     system    cpu+sys    elapsed
 ---------------------------------------------------------------------------------
   Checking hosts                          0.01       0.01       0.02       0.00
   Tests execution                         0.46       0.55       1.01       5.04
 ---------------------------------------------------------------------------------
   Total                                   0.51       0.57       1.08       5.12
 ---------------------------------------------------------------------------------

as_run 2021.0

------------------------------------------------------------
--- DIAGNOSTIC JOB : OK
------------------------------------------------------------

```

* fixes: https://github.com/aethereng/docker-codeaster/issues/3