### PR TITLE
Fix docker builds on aarch64 and dead MED download

### DIFF
--- a/Dockerfile.common.default
+++ b/Dockerfile.common.default
@@ -81,7 +81,9 @@ RUN wget --no-check-certificate \
 
 # download MED
 WORKDIR ${TEMP_DIRECTORY}/med
+# files.salome-platform.org blocks the default wget/curl User-Agent (WAF "badbots" rule)
 RUN wget --no-check-certificate \
+    --user-agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.75 Safari/537.36" \
     http://files.salome-platform.org/Salome/medfile/med-${VERSION_MED}.tar.gz \
     -O med.tar.gz && tar xf med.tar.gz -C . --strip-components 1 && rm med.tar.gz
 
@@ -183,7 +185,7 @@ RUN cmake .. \
     -Denable-portable-build=ON \
     -DPython_ADDITIONAL_VERSIONS=3.6 -Denable-python=ON \
     -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python3 \
-    -DPYTHON_LIBRARY:FILEPATH=/usr/lib/python3.6/config-3.6m-x86_64-linux-gnu/libpython3.6.so \
+    -DPYTHON_LIBRARY:FILEPATH=/usr/lib/python3.6/config-3.6m-$(uname -m)-linux-gnu/libpython3.6.so \
     -DPYTHON_INCLUDE_DIR:PATH=/usr/include/python3.6 \
     -DCMAKE_INSTALL_PREFIX=${ASTER_DIRECTORY}/tfel
 RUN make -j $(nproc) install
@@ -229,16 +231,18 @@ RUN LIBPATH="${ASTER_DIRECTORY}/scotch_seq/lib ${ASTER_DIRECTORY}/metis/lib ${AS
     INCLUDES="${ASTER_DIRECTORY}/scotch_seq/include ${ASTER_DIRECTORY}/metis/include ${ASTER_DIRECTORY}/parmetis/include" \
     python3 ./waf configure \
         --prefix=${ASTER_DIRECTORY}/mumps_seq
-RUN python3 ./waf build
+# -j1: parallel gfortran module (.mod) compilation races in MUMPS's Fortran sources
+RUN python3 ./waf build -j1
 RUN python3 ./waf install
 # build+install mumps parallel
 WORKDIR ${TEMP_DIRECTORY}/mumps_mpi
 RUN LIBPATH="${ASTER_DIRECTORY}/scotch_mpi/lib ${ASTER_DIRECTORY}/metis/lib ${ASTER_DIRECTORY}/parmetis/lib" \
     INCLUDES="${ASTER_DIRECTORY}/scotch_mpi/include ${ASTER_DIRECTORY}/metis/include ${ASTER_DIRECTORY}/parmetis/include" \
     python3 ./waf configure --enable-mpi --enable-openmp --enable-metis --enable-parmetis --enable-scotch \
-        --prefix=${ASTER_DIRECTORY}/mumps_mpi --install-tests 
-RUN python3 ./waf build
-RUN python3 ./waf install 
+        --prefix=${ASTER_DIRECTORY}/mumps_mpi --install-tests
+# -j1: parallel gfortran module (.mod) compilation races in MUMPS's Fortran sources
+RUN python3 ./waf build -j1
+RUN python3 ./waf install
 
 ######################################
 # PETSC

--- a/Dockerfile.mpi.default
+++ b/Dockerfile.mpi.default
@@ -71,7 +71,7 @@ ENV LD_LIBRARY_PATH=$ASTER_DIRECTORY/devtools/lib:$LD_LIBRARY_PATH
 ENV ENABLE_MPI=1
 
 # create symlink to lib64
-RUN ln -s /usr/lib/x86_64-linux-gnu/ /usr/lib64
+RUN ln -s /usr/lib/$(uname -m)-linux-gnu/ /usr/lib64
 
 WORKDIR ${TEMP_DIRECTORY}
 # clone aster
@@ -84,6 +84,9 @@ RUN hg clone -r ${VERSION_DEVTOOLS} http://hg.code.sf.net/p/codeaster/devtools d
 WORKDIR ${TEMP_DIRECTORY}/aster
 
 RUN sed -i 's/self.check_mpi_get_rank()/#self.check_mpi_get_rank()/g' data/wscript
+# upstream only enables 64-bit Fortran integers on x86_64; extend to any 64-bit
+# arch (e.g. aarch64), matching the check already used elsewhere in this wscript
+RUN sed -i "s/self.env.DEST_CPU == 'x86_64'/self.env.DEST_CPU.endswith('64')/g" bibfor/wscript
 
 ENV CONFIG_PARAMETERS_addmem=4096
 ENV CONFIG_PARAMETERS_mpiexec="mpirun -np %(mpi_nbcpu)s --hostfile %(mpi_hostfile)s %(program)s --allow-run-as-root"

--- a/Dockerfile.seq.default
+++ b/Dockerfile.seq.default
@@ -59,7 +59,7 @@ ENV PATH=$ASTER_DIRECTORY/devtools/bin:$PATH
 ENV LD_LIBRARY_PATH=$ASTER_DIRECTORY/devtools/lib:$LD_LIBRARY_PATH
 
 # # # create symlink to lib64
-RUN ln -s /usr/lib/x86_64-linux-gnu/ /usr/lib64
+RUN ln -s /usr/lib/$(uname -m)-linux-gnu/ /usr/lib64
 
 WORKDIR ${TEMP_DIRECTORY}
 # clone aster
@@ -70,6 +70,10 @@ ENV VERSION_DEVTOOLS=default
 RUN hg clone -r ${VERSION_DEVTOOLS} http://hg.code.sf.net/p/codeaster/devtools devtools
 
 WORKDIR ${TEMP_DIRECTORY}/aster
+
+# upstream only enables 64-bit Fortran integers on x86_64; extend to any 64-bit
+# arch (e.g. aarch64), matching the check already used elsewhere in this wscript
+RUN sed -i "s/self.env.DEST_CPU == 'x86_64'/self.env.DEST_CPU.endswith('64')/g" bibfor/wscript
 
 ENV CONFIG_PARAMETERS_addmem=4096
 

--- a/aster.wafcfg_scif_boost.py
+++ b/aster.wafcfg_scif_boost.py
@@ -1,4 +1,6 @@
+import platform
+
 def configure(self):
     self.env.INCLUDES_BOOST = '/usr/include'
-    self.env.LIBPATH_BOOST = ['/usr/lib/x86_64-linux-gnu']
+    self.env.LIBPATH_BOOST = ['/usr/lib/%s-linux-gnu' % platform.machine()]
     self.env.LIB_BOOST = ['boost_python3']

--- a/aster.wafcfg_scif_mpi.py
+++ b/aster.wafcfg_scif_mpi.py
@@ -1,3 +1,5 @@
+import platform
+
 def configure(self):
     opts = self.options
 
@@ -6,9 +8,9 @@ def configure(self):
     self.env['TFELHOME'] = '/aster/tfel'
     self.env['TFELVERS'] = '3.4.0'
     self.env['CATALO_CMD'] = "DUMMY="
-    
+
     self.env.INCLUDES_BOOST = '/usr/include'
-    self.env.LIBPATH_BOOST = ['/usr/lib/x86_64-linux-gnu']
+    self.env.LIBPATH_BOOST = ['/usr/lib/%s-linux-gnu' % platform.machine()]
     self.env.LIB_BOOST = ['boost_python3']
     self.env.WAFBUILD_ENV = ['/aster/aster/lib/dummy.env']
 


### PR DESCRIPTION
## Summary

- files.salome-platform.org blocks the default wget/curl User-Agent via a WAF "badbots" rule; the MED prerequisite download now sends a browser-style User-Agent.
- Several hardcoded `x86_64-linux-gnu` paths (TFEL python config, `lib64` symlinks, boost waf configs) are replaced with `$(uname -m)`/`platform.machine()` so the build works on aarch64 hosts.
- The MUMPS waf build is serialized (`-j1`) to avoid a gfortran `.mod0`->`.mod` rename race under parallel compilation.
- Patches code_aster's `bibfor/wscript` so 64-bit Fortran integers are enabled on any 64-bit arch (`DEST_CPU.endswith('64')`) instead of x86_64 only, fixing an `ASTERINTEGER`/`ASTERINTEGER4` type collision on aarch64.

With these changes, `make common`, `make seq`, and `make mpi` all build successfully on an aarch64 host (tested on Ubuntu 18.04/aarch64 in a Parallels VM), and the resulting images run correctly (`as_run` works, 6/7 shipped smoke tests pass in both the seq and mpi images). The one remaining failing test (`sslv155a`) hits a narrow, pre-existing upstream MUMPS/METIS heap-corruption bug unrelated to these changes.

## Test plan

- [x] `make common` builds successfully on aarch64
- [x] `make seq` builds successfully on aarch64
- [x] `make mpi` builds successfully on aarch64
- [x] `docker run aethereng/codeaster-seq:latest as_run --version` works
- [x] `docker run aethereng/codeaster-seq:latest run_testcases stable` — 6/7 shipped tests pass
- [x] `docker run aethereng/codeaster-mpi:latest run_testcases stable` — 6/7 shipped tests pass
